### PR TITLE
[FE-7847] Fix Open Setup Log Target

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -216,7 +216,7 @@ gotADir:
 		goto failedExtract;
 	}
 
-	swprintf_s(logFile, L"%s\\SquirrelSetup.log", targetDir);
+	swprintf_s(logFile, L"%s\\Squirrel-Install.log", targetDir);
 
 	
 	// New code to write the path of the currently running executable


### PR DESCRIPTION
## Summary

- The "Open Setup Log" button in the installation error dialog previously pointed to `SquirrelSetup.log`, which is a generic filename shared by all Squirrel-based applications.
- The actual install log written by `Update.exe` is `Squirrel-Install.log` (via `SetupLogLogger` with `commandSuffix = "Install"`), in the same `SquirrelTemp` directory.
- This one-line change in `UpdateRunner.cpp` fixes the filename so the button opens the correct, relevant log file.

## Test plan

- [ ] Build `Setup.exe` from this branch
- [ ] Run the installer in a scenario that triggers a failure (e.g., corrupt nupkg)
- [ ] Verify the "Open Setup Log" button opens `%localappdata%\SquirrelTemp\Squirrel-Install.log`
- [ ] Copy the compiled `Setup.exe` to `medal-electron/apps/desktop/tools/squirrel-vendor/Setup.exe`